### PR TITLE
Fix for PHP 5.3.7

### DIFF
--- a/src/Hugofirth/Mailchimp/MailchimpServiceProvider.php
+++ b/src/Hugofirth/Mailchimp/MailchimpServiceProvider.php
@@ -31,7 +31,7 @@ class MailchimpServiceProvider extends ServiceProvider {
 	public function register()
 	{
 		$this->app->singleton('mailchimp_wrapper',  function() {
-			$mc = new Mailchimp($this->app['config']->get('mailchimp::apikey'));
+			$mc = new Mailchimp(\Config::get('mailchimp::apikey'));
 
 			return new MailchimpWrapper($mc);
 		});


### PR DESCRIPTION
In PHP 5.3.7 the following errors occurs:

<code>[2013-10-18 11:31:45] log.ERROR: exception
'Symfony\Component\Debug\Exception\FatalErrorException' with message
'Using $this when not in object context' in
/home/azie01/domains/azie.justnotfinished.com/laravel/vendor/hugofirth/m
ailchimp/src/Hugofirth/Mailchimp/MailchimpServiceProvider.php:34
Stack trace:
#0 [internal function]: Illuminate\Exception\Handler->handleShutdown()
#1 {main} [] []</code>
