### PR TITLE
Add license indicator to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "hugofirth/mailchimp",
     "description": "Wrapper on the Mailchimp class provided by Mailchimp - with support for Laravel 4. v2.0.0 supports Mailchimp API verion 2.0",
     "keywords": ["laravel", "mailchimp"],
+    "license": "MIT",
     "authors": [
         {
             "name": "Hugo Firth",


### PR DESCRIPTION
MIT is used by both the MailChimp and Laravel. Seems like a logical choice here. Feel free to reject this PR if you want a different license, of course.
