### PR TITLE
Updated wrapper to use magic __call instead of tightly coupled methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,20 @@ Methods of the MailChimp api class work as described by the MailChimp API docs f
 	//Subscribe a user, with email: $email_address, to a list with id: $list_id
 	MailchimpWrapper::lists()->subscribe($list_id, array('email'=>$email_address));
 
+In order to allow for auto-completion, you can include a use statement for the Facade:
+
+    <?php
+
+    use Hugofirth\Mailchimp\Facades\MailchimpWrapper;
+
+    class SomeClass
+    {
+        public function someMethod()
+        {
+            MailchimpWrapper:: //You should be able to get auto completion here for the API methods/properties
+        }
+    }
+
 Enjoy!
 
 [1]: http://apidocs.mailchimp.com/api/downloads/#php

--- a/src/Hugofirth/Mailchimp/Facades/MailchimpWrapper.php
+++ b/src/Hugofirth/Mailchimp/Facades/MailchimpWrapper.php
@@ -4,6 +4,31 @@ namespace HugoFirth\Mailchimp\Facades;
 
 use Illuminate\Support\Facades\Facade;
 
+/**
+ * Class MailchimpWrapper
+ * Valid method/property list as of version Mailchimp API 2.0.4
+ * @method static \Mailchimp_Folders folders() accesses the $folders property
+ * @method static \Mailchimp_Templates templates() accesses the $templates property
+ * @method static \Mailchimp_Users users() accesses the $users property
+ * @method static \Mailchimp_Helper helper() accesses the $helper property
+ * @method static \Mailchimp_Mobile mobile() accesses the $mobile property
+ * @method static \Mailchimp_Ecomm ecomm() accesses the $ecomm property
+ * @method static \Mailchimp_Neapolitan neapolitan() accesses the $neapolitan property
+ * @method static \Mailchimp_Lists lists() accesses the $lists property
+ * @method static \Mailchimp_Campaigns campaigns() accesses the $campaigns property
+ * @method static \Mailchimp_Vip vip() accesses the $vip property
+ * @method static \Mailchimp_Reports reports() accesses the $reports property
+ * @method static \Mailchimp_Gallery gallery() accesses the $gallery property
+ * @method static bool ssl_verifypeer() accesses the $ssl_verifypeer property
+ * @method static bool ssl_verifyhost() accesses the $ssl_verifyhost property
+ * @method static string ssl_cainfo() accesses the $ssl_cainfo property
+ * @method static string apikey() accesses the $apikey property
+ * @method static bool debug() accesses the $debug property
+ * @method static array call($url, $params) accesses the call method
+ * @method static mixed readConfigs() accesses the readConfigs method
+ * @method static mixed caseError($result) accesses the castError method
+ * @method static void log($msg) accesses the log method
+ */
 class MailchimpWrapper extends Facade
 {
 	protected static function getFacadeAccessor()

--- a/src/Hugofirth/Mailchimp/MailchimpWrapper.php
+++ b/src/Hugofirth/Mailchimp/MailchimpWrapper.php
@@ -2,6 +2,31 @@
 
 use Mailchimp;
 
+/**
+ * Class MailchimpWrapper
+ * Valid method/property list as of version Mailchimp API 2.0.4
+ * @method \Mailchimp_Folders folders() accesses the $folders property
+ * @method \Mailchimp_Templates templates() accesses the $templates property
+ * @method \Mailchimp_Users users() accesses the $users property
+ * @method \Mailchimp_Helper helper() accesses the $helper property
+ * @method \Mailchimp_Mobile mobile() accesses the $mobile property
+ * @method \Mailchimp_Ecomm ecomm() accesses the $ecomm property
+ * @method \Mailchimp_Neapolitan neapolitan() accesses the $neapolitan property
+ * @method \Mailchimp_Lists lists() accesses the $lists property
+ * @method \Mailchimp_Campaigns campaigns() accesses the $campaigns property
+ * @method \Mailchimp_Vip vip() accesses the $vip property
+ * @method \Mailchimp_Reports reports() accesses the $reports property
+ * @method \Mailchimp_Gallery gallery() accesses the $gallery property
+ * @method bool ssl_verifypeer() accesses the $ssl_verifypeer property
+ * @method bool ssl_verifyhost() accesses the $ssl_verifyhost property
+ * @method string ssl_cainfo() accesses the $ssl_cainfo property
+ * @method string apikey() accesses the $apikey property
+ * @method bool debug() accesses the $debug property
+ * @method array call($url, $params) accesses the call method
+ * @method mixed readConfigs() accesses the readConfigs method
+ * @method mixed caseError($result) accesses the castError method
+ * @method void log($msg) accesses the log method
+ */
 class MailchimpWrapper {
 
 	/**
@@ -22,6 +47,13 @@ class MailchimpWrapper {
 		$this->mc = $mc;
 	}
 
+    /**
+     * Proxies call to the underlying MailChimp API
+     *
+     * @param $method
+     * @param array $args
+     * @return mixed
+     */
     public function __call($method, array $args)
     {
         //If it's a method, call it


### PR DESCRIPTION
This pull request fixes #3 in that it maps calls directly to the API instead of relying on hard coded methods. This should map any property or method called on the Mailchimp API class.
