### PR TITLE
Add branch-alias for 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,6 @@
         "branch-alias": {
             "dev-master": "2.0-dev"
         }
-    }
+    },
     "minimum-stability": "dev"
 }


### PR DESCRIPTION
So people can require `~2.0@dev`
